### PR TITLE
drop mac in one dev workflow (rest is still using mac)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,7 @@ jobs:
             build_type: Release
           - os: ubuntu-latest
             build_type: Debug
-          - os: macos-latest
-            build_type: Release
+
 
 
       fail-fast: false


### PR DESCRIPTION
the mac runners seem to not pick up jobs anymore (if we use to many??)
so I reduce the jobs which need mac